### PR TITLE
Allow emails with tilde

### DIFF
--- a/authapi/authmethods/tests.py
+++ b/authapi/authmethods/tests.py
@@ -152,6 +152,27 @@ class AuthMethodEmailTestCase(TestCase):
         response = c.authenticate(self.aeid, data)
         self.assertEqual(response.status_code, 400)
 
+    def test_method_email_authenticate_tilde(self):
+        email = "brüggemann@mail.com"
+
+        # Register
+        c = JClient()
+        data = { "email": email, "user": "tilde" }
+        response = c.register(self.aeid, data)
+        self.assertEqual(response.status_code, 200)
+        r = json.loads(response.content.decode("utf-8"))
+        self.assertEqual(r["status"], "ok")
+
+        code = Code.objects.get(user__user__email=email).code
+
+        data = { "email": email, "code": code }
+        response = c.authenticate(self.aeid, data)
+        self.assertEqual(response.status_code, 200)
+        r = json.loads(response.content.decode("utf-8"))
+        self.assertTrue(isinstance(r["username"], str))
+        self.assertTrue(len(r["username"]) > 0)
+        self.assertTrue(r["auth-token"].startswith("khmac:///sha-256"))
+
 
 class AuthMethodSmsTestCase(TestCase):
     def setUpTestData():

--- a/authapi/authmethods/utils.py
+++ b/authapi/authmethods/utils.py
@@ -80,6 +80,9 @@ def email_constraint(val):
     ''' check that the input is an email string '''
     if not isinstance(val, str):
         return False
+    # Convert to punycode to allow tilde characters:
+    # https://en.wikipedia.org/wiki/Punycode
+    val = val.encode("idna").decode("ascii")
     return EMAIL_RX.match(val)
 
 def date_constraint(val):


### PR DESCRIPTION
This patch convert emails to punycode[1] before validation so we'll
allow emails with tilde.

The email is stored as string and python supports unicode, so the only
part modified is the validation.

[1] https://en.wikipedia.org/wiki/Punycode