### PR TITLE
stabilizing paged census query

### DIFF
--- a/authapi/api/models.py
+++ b/authapi/api/models.py
@@ -433,13 +433,17 @@ class AuthEvent(models.Model):
                     user__children_event_id_list__contains=self.id
                 )
 
-        return ACL.objects.filter(
-            Q(
-                object_type='AuthEvent',
-                perm='vote',
-                object_id__isnull=False
-            ) & sub_query
-        )
+        # Note that we order so that paginated results are stable.
+        return ACL.objects\
+            .filter(
+                Q(
+                    object_type='AuthEvent',
+                    perm='vote',
+                    object_id__isnull=False
+                ) & sub_query
+            )\
+            .order_by('user_id')\
+            .distinct()
 
     def get_num_votes_query(self):
         '''


### PR DESCRIPTION
Previously, census query (used during census download in the admin UI) was not ordered by default. This meant that it by default the paging mechanism might not work well, because each page is done with a query that returns randomly ordered results. This resulted in the correct number of records, but some records were missing and some records were duplicated.

We solve it by sorting by default by increasing user_id. We also improve the census filter query to use QuerySet.extra(where="..") instead of having a full raw sql subquery and brute-force "user_id in <result from subquery>", which required bigger raw_sql duplicating the base census query. This probably makes filtering census queries more efficient/faster too.