### PR TITLE
Bump urllib3 from 1.25.11 to 1.26.8

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -56,7 +56,7 @@ pytz==2016.4
 PyYAML==6.0
 raven==5.19.0
 reportlab==3.5.55
-requests==2.22.0
+requests==2.27.1
 simplegeneric==0.8.1
 six==1.16.0
 sqlparse==0.4.2
@@ -65,7 +65,7 @@ toml==0.10.2
 traitlets==4.3.3
 twilio==6.6.1
 typing-extensions==4.0.1
-urllib3==1.25.11
+urllib3==1.26.8
 vine==5.0.0
 virtualenv==20.10.0
 wcwidth==0.2.5


### PR DESCRIPTION
The addition of all the implicit dependencies of authapi to the `requirements.txt` file (which happened in PR https://github.com/agoravoting/authapi/pull/171 ) has raised that urllib3 is also a dependency that requires an update. This set of PRs will fix that.