### PR TITLE
Children election listing

### DIFF
--- a/authapi/api/views.py
+++ b/authapi/api/views.py
@@ -1758,12 +1758,6 @@ class AuthEventView(View):
                     q &= Q(id__in=ids)
                 except:
                     ids = None
-            
-            if only_parent_elections is not None:
-                q &= (
-                    Q(parent_id=None) |
-                    Q(parent_id__isnull=False, children_election_info__isnull=False)
-                )
 
             serialize_method = 'serialize_restrict'
             if (
@@ -1794,6 +1788,28 @@ class AuthEventView(View):
                         'view-archived' in perms_split
                     ):
                         serialize_method = 'serialize'
+
+            if only_parent_elections is not None:
+                q &= (
+                    Q(parent_id=None) |
+                    Q(parent_id__isnull=False, children_election_info__isnull=False) |
+                    ~Q(
+                        parent_id__in=user.\
+                            userdata.\
+                            acls\
+                            .filter(
+                                object_type='AuthEvent',
+                                perm__in=perms_split
+                            )\
+                            .annotate(
+                                object_id_int=Cast(
+                                    'object_id',
+                                    output_field=IntegerField()
+                                )
+                            )\
+                            .values('object_id_int')
+                    )
+                )
 
             events = AuthEvent.objects.filter(q)
             aes = paginate(


### PR DESCRIPTION
When an admin user has permissions only to a children election, it was not being shown in the election list in admin ui.